### PR TITLE
feat: add T5 implementation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,8 +20,8 @@
                 "python.linting.enabled": true,
                 "editor.formatOnSave": true,
                 "editor.codeActionsOnSave": {
-                    "source.organizeImports": "true",
-                    "source.fixAll": "true"
+                    "source.organizeImports": "always",
+                    "source.fixAll": "always"
                 },
                 "python.formatting.provider": "none",
                 "[python]": {

--- a/examples/t5_inference_example.py
+++ b/examples/t5_inference_example.py
@@ -1,0 +1,21 @@
+from flax import nnx
+
+from jaxgarden import T5Config, T5ForCausalLM, Tokenizer
+
+if __name__ == "__main__":
+    config = T5Config()
+    model = T5ForCausalLM(config, rngs=nnx.Rngs(0))
+    model_id = "google-t5/t5-base"
+
+    # download checkpoint from HuggingFace Hub
+    model.from_hf(model_id, force_download=True)
+
+    tokenizer = Tokenizer.from_pretrained(model_id)
+
+    text = "The meaning of life is"
+    model_inputs = tokenizer.encode(text)
+    output = model.generate(**model_inputs, max_length=20, do_sample=True)
+    output_text = tokenizer.decode(output)
+
+    print(output, output.shape)
+    print(output_text)

--- a/jaxgarden/__init__.py
+++ b/jaxgarden/__init__.py
@@ -29,7 +29,7 @@ from jaxgarden.models.modernbert import (
     ModernBertLayer,
     ModernBertMLP,
 )
-from jaxgarden.tokenization import Tokenizer
+from jaxgarden.tokenization import Tokenizer  # type: ignore
 
 __all__ = [
     # Base classes

--- a/jaxgarden/__init__.py
+++ b/jaxgarden/__init__.py
@@ -29,9 +29,21 @@ from jaxgarden.models.modernbert import (
     ModernBertLayer,
     ModernBertMLP,
 )
+from jaxgarden.models.t5 import (
+    T5MLP,
+    T5Attention,
+    T5Block,
+    T5Config,
+    T5CrossAttention,
+    T5ForCausalLM,
+    T5LayerNorm,
+    T5SelfAttention,
+    T5Stack,
+)
 from jaxgarden.tokenization import Tokenizer  # type: ignore
 
 __all__ = [
+    "T5MLP",
     # Base classes
     "BaseConfig",
     "BaseModel",
@@ -60,6 +72,15 @@ __all__ = [
     "ModernBertMLP",
     # Attention modules
     "MultiHeadAttention",
+    # T5 Models
+    "T5Attention",
+    "T5Block",
+    "T5Config",
+    "T5CrossAttention",
+    "T5ForCausalLM",
+    "T5LayerNorm",
+    "T5SelfAttention",
+    "T5Stack",
     # tokenization
     "Tokenizer",
     # Functional interfaces

--- a/jaxgarden/attention/rope_multi_head_attention.py
+++ b/jaxgarden/attention/rope_multi_head_attention.py
@@ -47,8 +47,9 @@ def apply_rotary_pos_emb(x: jnp.ndarray, cos_emb: jnp.ndarray, sin_emb: jnp.ndar
     return (x * cos_emb) + (rotate_half(x) * sin_emb)
 
 
-def precompute_rotary_embeddings(seq_len: int, head_dim: int,
-    base: float = 10000.0) -> tuple[jnp.ndarray, jnp.ndarray]:
+def precompute_rotary_embeddings(
+    seq_len: int, head_dim: int, base: float = 10000.0
+) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Precomputes the RoPE cosine and sine embeddings.
 
     Args:
@@ -91,11 +92,11 @@ class RoPEMultiHeadAttention(nn.Module):
     rope_base: float = 10000.0
     dtype: jnp.dtype = jnp.float32
 
-    def setup(self) -> None: # Added -> None return type
+    def setup(self) -> None:  # Added -> None return type
         """Initializes the attention projections."""
         # Check head_dim validity early during setup
         if self.head_dim % 2 != 0:
-             raise ValueError(f"head_dim ({self.head_dim}) must be even for RoPE.")
+            raise ValueError(f"head_dim ({self.head_dim}) must be even for RoPE.")
 
         # Define layers here - they will be initialized when the module is first called
         total_head_dim = self.num_heads * self.head_dim
@@ -109,12 +110,11 @@ class RoPEMultiHeadAttention(nn.Module):
             features=total_head_dim, use_bias=False, dtype=self.dtype, name="value_proj"
         )
         self.output_proj = nn.Dense(
-            features=self.num_heads * self.head_dim, # Output should match embed_dim
+            features=self.num_heads * self.head_dim,  # Output should match embed_dim
             use_bias=False,
             dtype=self.dtype,
-            name="output_proj"
+            name="output_proj",
         )
-
 
     @nn.compact
     # Also using Optional for the mask type hint for clarity with None default
@@ -136,8 +136,7 @@ class RoPEMultiHeadAttention(nn.Module):
 
         if embed_dim != total_head_dim:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must equal num_heads*head_dim"
-                f" ({total_head_dim})"
+                f"embed_dim ({embed_dim}) must equal num_heads*head_dim ({total_head_dim})"
             )
         # Note: head_dim even check moved to setup for earlier failure
 
@@ -159,7 +158,6 @@ class RoPEMultiHeadAttention(nn.Module):
         cos_emb = cos_emb.astype(self.dtype)
         sin_emb = sin_emb.astype(self.dtype)
 
-
         # 4. Apply RoPE to Query and Key
         query = apply_rotary_pos_emb(query, cos_emb, sin_emb)
         key = apply_rotary_pos_emb(key, cos_emb, sin_emb)
@@ -172,31 +170,35 @@ class RoPEMultiHeadAttention(nn.Module):
         # 6. Scaled Dot-Product Attention
         # Attention scores: (batch, num_heads, seq_len, seq_len)
         attn_scores = jnp.matmul(query, key.transpose((0, 1, 3, 2))) / jnp.sqrt(
-            self.head_dim).astype(self.dtype) # Ensure sqrt is correct dtype
+            self.head_dim
+        ).astype(self.dtype)  # Ensure sqrt is correct dtype
 
         # Apply mask (if provided)
         if mask is not None:
             # Standard Flax causal mask is boolean (True means mask)
             # nn.make_causal_mask returns (1, seq_len, seq_len) or (batch, 1, seq_len, seq_len)
             # Check if mask needs broadcasting or conversion
-            if mask.ndim == 2: # Likely (seq_len, seq_len)
-                 mask = mask[None, None, :, :] # -> (1, 1, seq_len, seq_len)
+            if mask.ndim == 2:  # Likely (seq_len, seq_len)
+                mask = mask[None, None, :, :]  # -> (1, 1, seq_len, seq_len)
             elif mask.ndim == 3 and mask.shape[1] != self.num_heads:
-                 # Likely (batch, seq_len, seq_len) or causal (1, sl, sl)
+                # Likely (batch, seq_len, seq_len) or causal (1, sl, sl)
                 mask = mask[:, None, :, :]
-                     # Assume (batch, seq_len, seq_len) -> (batch, 1, seq_len, seq_len)
+                # Assume (batch, seq_len, seq_len) -> (batch, 1, seq_len, seq_len)
 
             # Ensure mask is broadcastable to attn_scores shape
             mask_shape_expected = (batch_size, self.num_heads, seq_len, seq_len)
             if mask.shape != mask_shape_expected:
-                 # Attempt broadcasting common causal mask shapes
-                 if mask.shape == (1, 1, seq_len, seq_len) or mask.shape == (batch_size, 1,
-                        seq_len, seq_len): # Causal mask for all batches/heads
-                     mask = jnp.broadcast_to(mask, mask_shape_expected)
-                 # Add other broadcasting cases if needed
-                 else:
-                     raise ValueError(f"Mask shape {mask.shape} != exp shape {mask_shape_expected}")
-
+                # Attempt broadcasting common causal mask shapes
+                if mask.shape == (1, 1, seq_len, seq_len) or mask.shape == (
+                    batch_size,
+                    1,
+                    seq_len,
+                    seq_len,
+                ):  # Causal mask for all batches/heads
+                    mask = jnp.broadcast_to(mask, mask_shape_expected)
+                # Add other broadcasting cases if needed
+                else:
+                    raise ValueError(f"Mask shape {mask.shape} != exp shape {mask_shape_expected}")
 
             # Apply mask: Use large negative number where mask is True
             # (or where mask value is 0 if using 0/-inf convention)
@@ -204,12 +206,10 @@ class RoPEMultiHeadAttention(nn.Module):
             # If using 0/-inf mask, the logic would be: attn_scores = attn_scores + mask
             attn_scores = jnp.where(mask, jnp.finfo(self.dtype).min, attn_scores)
 
-
         # Softmax to get attention weights
-        attn_weights = jax.nn.softmax(
-            attn_scores, axis=-1
-        ).astype(self.dtype)  # Shape: (batch, num_heads, seq_len, seq_len)
-
+        attn_weights = jax.nn.softmax(attn_scores, axis=-1).astype(
+            self.dtype
+        )  # Shape: (batch, num_heads, seq_len, seq_len)
 
         # Apply attention weights to Value
         # Output per head: (batch, num_heads, seq_len, head_dim)
@@ -222,6 +222,6 @@ class RoPEMultiHeadAttention(nn.Module):
         attn_output = attn_output.reshape(batch_size, seq_len, total_head_dim)
 
         # Final linear projection
-        output = self.output_proj(attn_output) # Use self.output_proj defined in setup
+        output = self.output_proj(attn_output)  # Use self.output_proj defined in setup
 
         return output

--- a/jaxgarden/models/base.py
+++ b/jaxgarden/models/base.py
@@ -71,7 +71,7 @@ class BaseModel(nnx.Module):
     @property
     def state(self) -> nnx.State:
         """Splits state from the graph and returns it"""
-        return nnx.split(self, nnx.Param, ...)[1]
+        return nnx.split(self, nnx.Param, ...)[1]  # type: ignore
 
     @property
     def state_dict(self) -> dict[str, jnp.ndarray]:

--- a/jaxgarden/models/gemma2.py
+++ b/jaxgarden/models/gemma2.py
@@ -422,7 +422,7 @@ class Gemma2DecoderLayer(nnx.Module):
 
 
 # 3. Main Model
-class Gemma2ForCausalLM(BaseModel, GenerationMixin):
+class Gemma2ForCausalLM(GenerationMixin, BaseModel):
     config: Gemma2Config  # This helps to fix a mypy issue
 
     def __init__(self, config: Gemma2Config, *, rngs: nnx.Rngs) -> None:

--- a/jaxgarden/models/llama.py
+++ b/jaxgarden/models/llama.py
@@ -431,7 +431,7 @@ class LlamaTransformerBlock(nnx.Module):
         return x
 
 
-class LlamaForCausalLM(BaseModel, GenerationMixin):
+class LlamaForCausalLM(GenerationMixin, BaseModel):
     """LLama model for causal language modeling.
 
     This implements the full LLama model for generating text.
@@ -511,7 +511,7 @@ class LlamaForCausalLM(BaseModel, GenerationMixin):
         assert input_ids.shape[0] == 1, "Only batch size 1 is supported"
         print(input_ids.shape)
         position_ids = jnp.arange(input_ids.shape[-1])[None, :].astype(jnp.int32)
-        attention_mask = jnp.where(attention_mask, 0.0, -jnp.inf)[None, None, ...]
+        attention_mask = jnp.where(attention_mask, 0.0, -jnp.inf)[None, None, ...]  # type: ignore
         x = self.token_embed(input_ids)
         for layer in self.layers:
             x = layer(x, position_ids, attention_mask)

--- a/jaxgarden/models/t5.py
+++ b/jaxgarden/models/t5.py
@@ -1,15 +1,24 @@
+import typing
 from dataclasses import dataclass
 
 import flax.nnx as nnx
+import jax
 import jax.numpy as jnp
+from flax.nnx import combine_masks, dot_product_attention, make_causal_mask
+from jax.typing import ArrayLike
 
 from jaxgarden.models.base import BaseConfig
 
 
 @dataclass
 class T5Config(BaseConfig):
-    dim: int = 1024
+    hidden_size: int = 768
+    dim_ff: int = 3072
+    dim_kv: int = 64
     intermediate_dim: int = 4096
+    num_heads: int = 12
+    relative_attention_num_buckets: int = 32
+    relative_attention_max_distance: int = 128
     initializer_factor: float = 1.0
     dropout_rate: float = 0.1
     layer_norm_epsilon: float = 1e-6
@@ -84,3 +93,330 @@ class T5MLP(nnx.Module):
         hidden_states = self.output_dense(hidden_states)
         x = x + self.dropout(hidden_states, deterministic=deterministic)
         return x.astype(self.dtype)
+
+
+class T5Attention(nnx.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        dim_kv: int,
+        num_heads: int,
+        relative_attention_num_buckets: int,
+        relative_attention_max_distance: int,
+        causal: bool | None = False,
+        has_relative_attention_bias: bool | None = False,
+        initializer_factor: float = 1.0,
+        dropout_rate: float = 0.1,
+        *,
+        dtype: jnp.dtype = jnp.float32,
+        rngs: nnx.Rngs,
+    ):
+        self.hidden_size = hidden_size
+        self.dim_kv = dim_kv
+        self.num_heads = num_heads
+        self.relative_attention_num_buckets = relative_attention_num_buckets
+        self.relative_attention_max_distance = relative_attention_max_distance
+        self.causal = causal
+        self.has_relative_attention_bias = has_relative_attention_bias
+        self.initializer_factor = initializer_factor
+        self.dropout_rate = dropout_rate
+
+        self.dtype = dtype
+        self.rngs = rngs
+
+        self.inner_dim = self.num_heads * self.dim_kv
+
+        q_init_std = self.initializer_factor * ((self.inner_dim * self.dim_kv) ** -0.5)
+        kv_init_std = self.initializer_factor * (self.inner_dim**-0.5)
+        o_init_std = self.initializer_factor * (self.inner_dim**-0.5)
+
+        self.q = nnx.Linear(
+            in_features=self.hidden_size,
+            out_features=self.inner_dim,
+            kernel_init=nnx.initializers.normal(q_init_std, dtype=dtype),
+            dtype=dtype,
+            rngs=rngs,
+            use_bias=False,
+        )
+        self.k = nnx.Linear(
+            in_features=self.hidden_size,
+            out_features=self.inner_dim,
+            kernel_init=nnx.initializers.normal(kv_init_std, dtype=dtype),
+            dtype=dtype,
+            rngs=rngs,
+            use_bias=False,
+        )
+        self.v = nnx.Linear(
+            in_features=self.hidden_size,
+            out_features=self.inner_dim,
+            kernel_init=nnx.initializers.normal(kv_init_std, dtype=dtype),
+            dtype=dtype,
+            rngs=rngs,
+            use_bias=False,
+        )
+        self.o = nnx.Linear(
+            in_features=self.inner_dim,
+            out_features=self.hidden_size,
+            kernel_init=nnx.initializers.normal(o_init_std, dtype=dtype),
+            dtype=dtype,
+            rngs=rngs,
+            use_bias=False,
+        )
+
+        if self.has_relative_attention_bias:
+            self.relative_attention_bias = nnx.Embed(
+                num_embeddings=self.relative_attention_num_buckets,
+                features=self.num_heads,
+                embedding_init=nnx.initializers.normal(kv_init_std, dtype=dtype),
+                dtype=dtype,
+                rngs=rngs,
+            )
+
+    @typing.no_type_check
+    @staticmethod
+    def _relative_position_bucket(
+        relative_position: ArrayLike,
+        bidirectional: bool = True,
+        num_buckets: int = 32,
+        max_distance: int = 128,
+    ) -> jnp.ndarray:
+        """
+        Borrowed from Hugging Face T5 implementation:
+        https://github.com/huggingface/transformers/blob/b59386dc0a44eef0b6c671ed6ed09a76b75235e8/src/transformers/models/t5/modeling_flax_t5.py#L232
+
+        Adapted from Mesh Tensorflow:
+        https://github.com/tensorflow/mesh/blob/0cb87fe07da627bf0b7e60475d59f95ed6b5be3d/mesh_tensorflow/transformer/transformer_layers.py#L593
+
+        Translate relative position to a bucket number for relative attention. The relative position is defined as
+        memory_position - query_position, i.e. the distance in tokens from the attending position to the attended-to
+        position. If bidirectional=False, then positive relative positions are invalid. We use smaller buckets for
+        small absolute relative_position and larger buckets for larger absolute relative_positions. All relative
+        positions >=max_distance map to the same bucket. All relative positions <=-max_distance map to the same bucket.
+        This should allow for more graceful generalization to longer sequences than the model has been trained on
+        """  # noqa: E501
+
+        relative_buckets = 0
+        if bidirectional:
+            num_buckets //= 2
+            relative_buckets += (relative_position > 0) * num_buckets
+            relative_position = jnp.abs(relative_position)
+        else:
+            relative_position = -jnp.clip(relative_position, a_max=0)
+        # now relative_position is in the range [0, inf)
+
+        # half of the buckets are for exact increments in positions
+        max_exact = num_buckets // 2
+        is_small = relative_position < max_exact
+
+        # The other half of the buckets are for logarithmically
+        # bigger bins in positions upto max_distance
+        relative_position_if_large = max_exact + (
+            jnp.log(relative_position / max_exact)
+            / jnp.log(max_distance / max_exact)
+            * (num_buckets - max_exact)
+        )
+        relative_position_if_large = jnp.clip(relative_position_if_large, a_max=num_buckets - 1)
+
+        relative_buckets += jnp.where(is_small, relative_position, relative_position_if_large)
+        return relative_buckets.astype("i4")
+
+    def compute_bias(self, query_length: int, key_length: int) -> jnp.ndarray:
+        """
+        Compute binned relative position bias
+
+        Borrowed from Hugging Face T5 implementation:
+        https://github.com/huggingface/transformers/blob/b59386dc0a44eef0b6c671ed6ed09a76b75235e8/src/transformers/models/t5/modeling_flax_t5.py#L267
+        """
+        context_position = jnp.arange(query_length, dtype="i4")[:, None]
+        memory_position = jnp.arange(key_length, dtype="i4")[None, :]
+
+        relative_position = memory_position - context_position
+        relative_position_bucket = self._relative_position_bucket(
+            relative_position,
+            bidirectional=(not self.causal),
+            num_buckets=self.relative_attention_num_buckets,
+            max_distance=self.relative_attention_max_distance,
+        )
+
+        values = self.relative_attention_bias(relative_position_bucket)
+        values = values.transpose((2, 0, 1))[None, :, :, :]
+        return values
+
+    def _split_heads(self, hidden_states: jnp.ndarray) -> jnp.ndarray:
+        return hidden_states.reshape(hidden_states.shape[:2] + (self.num_heads, self.dim_kv))
+
+    def _merge_heads(self, hidden_states: jnp.ndarray) -> jnp.ndarray:
+        return hidden_states.reshape(hidden_states.shape[:2] + (self.inner_dim,))
+
+    def _create_position_bias(
+        self,
+        key_states: jnp.ndarray,
+        query_states: jnp.ndarray,
+        attention_mask: jnp.ndarray | None = None,
+    ) -> jnp.ndarray:
+        key_length = key_states.shape[1]
+        query_length = query_states.shape[1]
+
+        if self.has_relative_attention_bias:
+            position_bias = self.compute_bias(query_length, key_length)
+        elif attention_mask is not None:
+            position_bias = jnp.zeros_like(attention_mask)
+        else:
+            position_bias = jnp.zeros(
+                (1, self.num_heads, query_length, key_length), dtype=self.dtype
+            )
+
+        return position_bias
+
+    def __call__(
+        self,
+        hidden_states: jnp.ndarray,
+        attention_mask: jnp.ndarray | None = None,
+        key_value_states: jnp.ndarray | None = None,
+        position_bias: jnp.ndarray | None = None,
+        deterministic: bool = True,
+    ) -> jnp.ndarray:
+        batch_size, seq_length = hidden_states.shape[:2]
+
+        if attention_mask is None:
+            attention_mask = jnp.ones((batch_size, seq_length), dtype="bool")
+
+        # ----- Q, K, V -----
+        query_states = self.q(hidden_states)
+        key_states = self.k(hidden_states) if key_value_states is None else self.k(key_value_states)
+        value_states = (
+            self.v(hidden_states) if key_value_states is None else self.v(key_value_states)
+        )
+        query_states = self._split_heads(query_states)
+        key_states = self._split_heads(key_states)
+        value_states = self._split_heads(value_states)
+
+        # ----- Attention Mask -----
+        if self.causal:
+            causal_attention_mask = make_causal_mask(attention_mask, dtype="bool")
+            causal_attention_mask = jnp.broadcast_to(
+                causal_attention_mask, (batch_size,) + causal_attention_mask.shape[1:]
+            )
+            attention_mask_broadcast = jnp.broadcast_to(
+                jnp.expand_dims(attention_mask, axis=(-3, -2)), causal_attention_mask.shape
+            )
+            attention_mask = combine_masks(
+                attention_mask_broadcast, causal_attention_mask, dtype=self.dtype
+            )
+        else:
+            attention_mask = jnp.expand_dims(attention_mask, axis=(-3, -2))
+
+        if attention_mask is not None:
+            mask_value = jnp.finfo(self.dtype).min
+            attention_mask = jax.lax.select(
+                attention_mask > 0,
+                jnp.full(attention_mask.shape, 0.0).astype(self.dtype),
+                jnp.full(attention_mask.shape, mask_value).astype(self.dtype),
+            )
+
+        if position_bias is None:
+            # compute position bias (only for first layer)
+            position_bias = self._create_position_bias(
+                key_states,
+                query_states,
+                attention_mask,
+            )
+
+            if attention_mask is not None:
+                position_bias = position_bias + attention_mask
+
+        # create dropout rng
+        dropout_rng = None
+        if not deterministic and self.dropout_rate > 0.0 and self.rngs is not None:
+            dropout_rng = self.rngs.dropout()
+
+        # --- Attention ---
+        attn_weights = dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            bias=position_bias,
+            dropout_rng=dropout_rng,
+            dropout_rate=self.dropout_rate,
+            broadcast_dropout=True,
+            deterministic=deterministic,
+            dtype=self.dtype,
+        )
+
+        attn_output = self._merge_heads(attn_weights)
+        attn_output = self.o(attn_output)
+        return attn_output
+
+
+class T5SelfAttention(nnx.Module):
+    def __init__(
+        self,
+        config: T5Config,
+        causal: bool = True,
+        has_relative_attention_bias: bool = False,
+        *,
+        rngs: nnx.Rngs,
+    ):
+        self.config = config
+        self.attention = T5Attention(
+            hidden_size=config.hidden_size,
+            dim_kv=config.dim_kv,
+            num_heads=config.num_heads,
+            relative_attention_num_buckets=config.relative_attention_num_buckets,
+            relative_attention_max_distance=config.relative_attention_max_distance,
+            causal=causal,
+            has_relative_attention_bias=has_relative_attention_bias,
+            rngs=rngs,
+        )
+
+        self.layer_norm = T5LayerNorm(dim=config.hidden_size, dtype=config.dtype, rngs=rngs)
+        self.dropout = nnx.Dropout(rate=config.dropout_rate, rngs=rngs)
+
+    def __call__(
+        self,
+        hidden_states: jnp.ndarray,
+        attention_mask: jnp.ndarray | None = None,
+        deterministic: bool = True,
+    ) -> jnp.ndarray:
+        hidden_states = self.layer_norm(hidden_states)
+        attn_output = self.attention(
+            hidden_states, attention_mask=attention_mask, deterministic=deterministic
+        )
+        hidden_states = hidden_states + self.dropout(attn_output, deterministic=deterministic)
+        return hidden_states.astype(self.config.dtype)
+
+
+class T5CrossAttention(nnx.Module):
+    def __init__(
+        self,
+        config: T5Config,
+        *,
+        rngs: nnx.Rngs,
+    ):
+        self.config = config
+        self.attention = T5Attention(
+            hidden_size=config.hidden_size,
+            dim_kv=config.dim_kv,
+            num_heads=config.num_heads,
+            relative_attention_num_buckets=config.relative_attention_num_buckets,
+            relative_attention_max_distance=config.relative_attention_max_distance,
+            causal=False,
+            has_relative_attention_bias=False,
+            rngs=rngs,
+        )
+
+        self.layer_norm = T5LayerNorm(dim=config.hidden_size, dtype=config.dtype, rngs=rngs)
+        self.dropout = nnx.Dropout(rate=config.dropout_rate, rngs=rngs)
+
+    def __call__(
+        self,
+        hidden_states: jnp.ndarray,
+        attention_mask: jnp.ndarray | None = None,
+        deterministic: bool = True,
+    ) -> jnp.ndarray:
+        hidden_states = self.layer_norm(hidden_states)
+        attn_output = self.attention(
+            hidden_states, attention_mask=attention_mask, deterministic=deterministic
+        )
+        hidden_states = hidden_states + self.dropout(attn_output, deterministic=deterministic)
+        return hidden_states.astype(self.config.dtype)

--- a/jaxgarden/models/t5.py
+++ b/jaxgarden/models/t5.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+
+import flax.nnx as nnx
+import jax.numpy as jnp
+
+from jaxgarden.models.base import BaseConfig
+
+
+@dataclass
+class T5Config(BaseConfig):
+    dim: int = 1024
+    intermediate_dim: int = 4096
+    initializer_factor: float = 1.0
+    dropout_rate: float = 0.1
+    layer_norm_epsilon: float = 1e-6
+    dtype: jnp.dtype = jnp.float32
+
+
+class T5LayerNorm(nnx.Module):
+    def __init__(
+        self,
+        dim: int,
+        eps: float = 1e-6,
+        *,
+        dtype: jnp.dtype = jnp.float32,
+        rngs: nnx.Rngs,
+    ):
+        self.eps = eps
+        self.dtype = dtype
+        self.weight = nnx.initializers.ones(rngs.params(), (dim,), dtype=dtype)
+
+    def __call__(self, hidden_states: jnp.ndarray) -> jnp.ndarray:
+        variance = jnp.power(hidden_states.astype(jnp.float32), 2).mean(axis=-1, keepdims=True)
+        hidden_states = hidden_states / jnp.sqrt(variance + self.eps)
+
+        hidden_states = hidden_states.astype(self.dtype)
+        return self.weight * hidden_states
+
+
+class T5MLP(nnx.Module):
+    def __init__(
+        self,
+        dim: int,
+        intermediate_dim: int,
+        initializer_factor: float = 1.0,
+        dropout_rate: float = 0.1,
+        *,
+        dtype: jnp.dtype = jnp.float32,
+        rngs: nnx.Rngs,
+    ):
+        self.dim = dim
+        self.dtype = dtype
+        self.intermediate_dim = intermediate_dim
+        self.initializer_factor = initializer_factor
+
+        input_init_std = self.initializer_factor * (self.dim**-0.5)
+        output_init_std = self.initializer_factor * (self.intermediate_dim**-0.5)
+
+        self.layer_norm = T5LayerNorm(dim=dim, dtype=dtype, rngs=rngs)
+        self.input_dense = nnx.Linear(
+            in_features=dim,
+            out_features=intermediate_dim,
+            use_bias=False,
+            kernel_init=nnx.initializers.normal(input_init_std, dtype=dtype),
+            dtype=dtype,
+            rngs=rngs,
+        )
+        self.act = nnx.relu
+        self.dropout = nnx.Dropout(rate=dropout_rate, rngs=rngs)
+        self.output_dense = nnx.Linear(
+            in_features=intermediate_dim,
+            out_features=dim,
+            use_bias=False,
+            kernel_init=nnx.initializers.normal(output_init_std, dtype=dtype),
+            dtype=dtype,
+            rngs=rngs,
+        )
+
+    def __call__(self, x: jnp.ndarray, deterministic: bool = True) -> jnp.ndarray:
+        hidden_states = self.layer_norm(x)
+        hidden_states = self.input_dense(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.dropout(hidden_states, deterministic=deterministic)
+        hidden_states = self.output_dense(hidden_states)
+        x = x + self.dropout(hidden_states, deterministic=deterministic)
+        return x.astype(self.dtype)

--- a/jaxgarden/models/t5.py
+++ b/jaxgarden/models/t5.py
@@ -1,3 +1,11 @@
+"""
+T5 model implementation in JAX using Flax NNX.
+
+This module implements the T5 architecture as described in Google's T5 series of models.
+
+See: https://jmlr.org/papers/volume21/20-074/20-074.pdf
+"""
+
 import typing
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -15,6 +23,31 @@ from jaxgarden.models.generation_utils import GenerationMixin
 
 @dataclass
 class T5Config(BaseConfig):
+    """
+    Configuration for T5 model.
+
+    This configuration class extends BaseConfig and contains all the parameters
+    required to initialize a T5 model. It includes settings for model architecture,
+    attention mechanisms, and other hyperparameters.
+
+    This default configuration is based on the original t5-base variant.
+
+    Attributes:
+        vocab_size: Size of vocabulary
+        hidden_size: Size of hidden states
+        dim_ff: Size of feed-forward layer
+        dim_kv: Size of key/value states
+        intermediate_dim: Size of intermediate layer
+        num_heads: Number of attention heads
+        num_layers: Number of layers
+        relative_attention_num_buckets: Number of buckets for relative attention
+        relative_attention_max_distance: Maximum distance for relative attention
+        initializer_factor: Factor for initializing weights
+        dropout_rate: Dropout rate
+        layer_norm_epsilon: Epsilon for layer normalization
+        dtype: Data type for the model
+    """
+
     vocab_size: int = 32128
     hidden_size: int = 768
     dim_ff: int = 3072
@@ -31,6 +64,10 @@ class T5Config(BaseConfig):
 
 
 class T5LayerNorm(nnx.Module):
+    """
+    LayerNorm module in the T5 style; No bias and no subtraction of mean.
+    """
+
     def __init__(
         self,
         dim: int,

--- a/tests/attention/test_RoPEMultiHeadAttention.py
+++ b/tests/attention/test_RoPEMultiHeadAttention.py
@@ -65,8 +65,8 @@ def test_apply_rotary_pos_emb():
     assert not jnp.allclose(rotated_x, x)
 
 
-
 # --- Test RoPEMultiHeadAttention Module ---
+
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16])
 def test_rope_mha_forward_pass(dtype):
@@ -99,7 +99,7 @@ def test_rope_mha_masking():
 
     x = jax.random.normal(key, (batch_size, seq_len, embed_dim))
     # Create a causal mask (True means masked)
-    causal_mask = nn.make_causal_mask(x[:, :, 0]) # Gets (batch, seq, seq) or (1, seq, seq)
+    causal_mask = nn.make_causal_mask(x[:, :, 0])  # Gets (batch, seq, seq) or (1, seq, seq)
 
     rope_mha = RoPEMultiHeadAttention(num_heads=num_heads, head_dim=head_dim)
     params = rope_mha.init(key, x, causal_mask)["params"]
@@ -123,14 +123,11 @@ def test_rope_mha_errors():
     x_dummy_odd = jax.random.normal(key, (2, 16, 8 * 7))
     # Test with odd head_dim (should raise error during initialization/setup)
     with pytest.raises(ValueError, match=r"head_dim \(\d+\) must be even"):
-
         rope_mha_odd_dim.init(key, x_dummy_odd)
 
-
     # Test with mismatched embed_dim (should raise error during forward pass / init)
-    rope_mha = RoPEMultiHeadAttention(num_heads=4, head_dim=8) # Expects embed_dim 32
-    x_mismatch = jax.random.normal(key, (2, 16, 100)) # Incorrect embed_dim
+    rope_mha = RoPEMultiHeadAttention(num_heads=4, head_dim=8)  # Expects embed_dim 32
+    x_mismatch = jax.random.normal(key, (2, 16, 100))  # Incorrect embed_dim
 
     with pytest.raises(ValueError, match=r"embed_dim \(\d+\) must equal"):
         rope_mha.init(key, x_mismatch)
-

--- a/tests/models/test_t5.py
+++ b/tests/models/test_t5.py
@@ -2,7 +2,14 @@ import jax.numpy as jnp
 import pytest
 from flax import nnx
 
-from jaxgarden.models.t5 import T5MLP, T5LayerNorm
+from jaxgarden.models.t5 import (
+    T5MLP,
+    T5Attention,
+    T5Config,
+    T5CrossAttention,
+    T5LayerNorm,
+    T5SelfAttention,
+)
 
 
 @pytest.mark.parametrize(("dim", "dtype"), [(1024, jnp.float32), (2048, jnp.float16)])
@@ -20,11 +27,77 @@ def test_t5_layer_norm(dim, dtype):
 )
 def test_t5_mlp(dim, intermediate_dim, dtype):
     # small sequence length for testing
-    seq_len = 256
+    seq_len = 128
 
     mlp = T5MLP(dim=dim, intermediate_dim=intermediate_dim, dtype=dtype, rngs=nnx.Rngs(0))
     x = jnp.ones((1, seq_len, dim))
     output = mlp(x)
 
     assert output.shape == (1, seq_len, dim)
+    assert output.dtype == dtype
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "dim_kv", "dtype", "masked"),
+    [(768, 64, jnp.float32, True), (1024, 128, jnp.float16, False)],
+)
+def test_t5_attention(hidden_size, dim_kv, dtype, masked):
+    # small sequence length for testing
+    seq_len = 128
+
+    attention = T5Attention(
+        hidden_size=hidden_size,
+        dim_kv=dim_kv,
+        num_heads=hidden_size // dim_kv,
+        relative_attention_num_buckets=32,
+        relative_attention_max_distance=128,
+        dtype=dtype,
+        rngs=nnx.Rngs(0),
+    )
+
+    hidden_states = jnp.ones((1, seq_len, hidden_size))
+    attention_mask = jnp.ones((1, seq_len)) if masked else None
+    output = attention(hidden_states, attention_mask=attention_mask)
+
+    assert output.shape == (1, seq_len, hidden_size)
+    assert output.dtype == dtype
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "dim_kv", "dtype", "masked"),
+    [(768, 64, jnp.float32, True), (1024, 128, jnp.float16, False)],
+)
+def test_t5_self_attention(hidden_size, dim_kv, dtype, masked):
+    # small sequence length for testing
+    seq_len = 128
+
+    config = T5Config(hidden_size=hidden_size, dim_kv=dim_kv, dtype=dtype)
+    self_attention = T5SelfAttention(config=config, rngs=nnx.Rngs(0))
+
+    hidden_states = jnp.ones((1, seq_len, hidden_size))
+    attention_mask = jnp.ones((1, seq_len)) if masked else None
+
+    output = self_attention(hidden_states, attention_mask=attention_mask)
+
+    assert output.shape == (1, seq_len, hidden_size)
+    assert output.dtype == dtype
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "dim_kv", "dtype", "masked"),
+    [(768, 64, jnp.float32, True), (1024, 128, jnp.float16, False)],
+)
+def test_t5_cross_attention(hidden_size, dim_kv, dtype, masked):
+    # small sequence length for testing
+    seq_len = 128
+
+    config = T5Config(hidden_size=hidden_size, dim_kv=dim_kv, dtype=dtype)
+    cross_attention = T5CrossAttention(config=config, rngs=nnx.Rngs(0))
+
+    hidden_states = jnp.ones((1, seq_len, hidden_size))
+    attention_mask = jnp.ones((1, seq_len)) if masked else None
+
+    output = cross_attention(hidden_states, attention_mask=attention_mask)
+
+    assert output.shape == (1, seq_len, hidden_size)
     assert output.dtype == dtype

--- a/tests/models/test_t5.py
+++ b/tests/models/test_t5.py
@@ -1,0 +1,30 @@
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from jaxgarden.models.t5 import T5MLP, T5LayerNorm
+
+
+@pytest.mark.parametrize(("dim", "dtype"), [(1024, jnp.float32), (2048, jnp.float16)])
+def test_t5_layer_norm(dim, dtype):
+    layer_norm = T5LayerNorm(dim=dim, dtype=dtype, rngs=nnx.Rngs(0))
+    x = jnp.ones((1, dim))
+    output = layer_norm(x)
+
+    assert output.shape == (1, dim)
+    assert output.dtype == dtype
+
+
+@pytest.mark.parametrize(
+    ("dim", "intermediate_dim", "dtype"), [(512, 2048, jnp.float32), (1024, 4096, jnp.float16)]
+)
+def test_t5_mlp(dim, intermediate_dim, dtype):
+    # small sequence length for testing
+    seq_len = 256
+
+    mlp = T5MLP(dim=dim, intermediate_dim=intermediate_dim, dtype=dtype, rngs=nnx.Rngs(0))
+    x = jnp.ones((1, seq_len, dim))
+    output = mlp(x)
+
+    assert output.shape == (1, seq_len, dim)
+    assert output.dtype == dtype


### PR DESCRIPTION
Adds T5 Implementation (#34)

* fixes linter/type-checker warnings (`ruff` + `mypy`). Affected Files:
	* `jaxgarden/__init__.py`
	* `jaxgarden/attention/rope_multi_head_attention.py`
	* `jaxgarden/models/base.py`
	* `tests/attention/test_RoPEMultiHeadAttention.py`	
* also fixes #28. Affected Files:
	* `jaxgarden/models/gemma2.py`
	* `jaxgarden/models/llama.py`
* makes minor modifications to `jaxgarden/tokenization.py` to handle edge cases of special tokens

#### References
* https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_flax_t5.py